### PR TITLE
changed query condition to LanguageName

### DIFF
--- a/dist/main.js
+++ b/dist/main.js
@@ -11,27 +11,9 @@
     'use strict';
     /**********************************************
      * langsの中から自分が使用する言語に変更してください
+     * ex) C#, Python3, Rust, Java
     ***********************************************/
     const lang = 'C++';
-    const langs = {
-        'C++': 3003,
-        'C#': 3006,
-        'C': 3002,
-        'Python3': 3023,
-        'PyPy3': 3510,
-        'Ruby': 3024,
-        'Java': 3016,
-        'JavaScript': 3017,
-        'TypeScript': 3521,
-        'PHP': 3524,
-        'Haskell': 3014,
-        'Go': 3013,
-        'Scala': 3025,
-        'Perl': 3020,
-        'Swift': 3503,
-        'Rust': 3504,
-        'Kotlin': 3523
-    };
     // 問題ページにいるときは問題番号での絞り込みも追加
     const taskPage = location.href.match(/tasks\/(.+?)$/);
     let task = '';
@@ -40,7 +22,7 @@
     }
     const params = {
         'f.Task': task,
-        'f.Language': langs[lang],
+        'f.LanguageName': lang,
         // AC, WA, TLE, MLE, RE, CE, QLE, OLE, IE, WJ, WR, Judging
         'f.Status': 'AC',
         // source_length, time_consumption, memory_consumption, score

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,28 +12,9 @@
     'use strict';
     /**********************************************
      * langsの中から自分が使用する言語に変更してください
+     * ex) C#, Python3, Rust, Java
     ***********************************************/
     const lang = 'C++';
-    const langs = {
-        'C++': 3003,
-        'C#': 3006,
-        'C': 3002,
-        'Python3': 3023,
-        'PyPy3': 3510,
-        'Ruby': 3024,
-        'Java': 3016,
-        'JavaScript': 3017,
-        'TypeScript': 3521,
-        'PHP': 3524,
-        'Haskell': 3014,
-        'Go': 3013,
-        'Scala': 3025,
-        'Perl': 3020,
-        'Swift': 3503,
-        'Rust': 3504,
-        'Kotlin': 3523
-    };
-
     // 問題ページにいるときは問題番号での絞り込みも追加
     const taskPage = location.href.match(/tasks\/(.+?)$/);
     let task = '';
@@ -41,9 +22,9 @@
         task = taskPage[1];
     }
 
-    const params: {[key:string]: string|number} = {
+    const params: { [key: string]: string } = {
         'f.Task': task,
-        'f.Language': langs[lang],
+        'f.LanguageName': lang,
         // AC, WA, TLE, MLE, RE, CE, QLE, OLE, IE, WJ, WR, Judging
         'f.Status': 'AC',
         // source_length, time_consumption, memory_consumption, score


### PR DESCRIPTION
クエリ条件を`Language`から`LanguageName`に変更しました。
AtCoder側にて言語のバージョンアップを行うと適切に絞り込みが行われないためです。
(自分が使用している`Rust`がうまく使えず気づきました)

また、`package.json`のコミットもよければお願いしたいです！
(今回変換は`tsc --target ES6 ./src/main.ts`で行いました)
